### PR TITLE
fix: Remove the Pa to kPa conversion on sensor dump for baro pres

### DIFF
--- a/Sensor/create_sensors.py
+++ b/Sensor/create_sensors.py
@@ -36,7 +36,7 @@ def flight_computer_rev2_sensors() -> List[Sensor]:
         (b"\x12", "velo_z", "Velo Z", 4, float, "m/s", None),
 
         (b"\x13", "pos", "Position", 4, float, "m", None),
-        (b"\x14", "pres", "Barometric Pressure", 4, float, "kPa", baro_press),
+        (b"\x14", "pres", "Barometric Pressure", 4, float, "kPa", None),
         (b"\x15", "temp", "Barometric Temperature", 4, float, "C", None),
         (b"\x16", "alt", "Barometric Altitude", 4, float, "m", None),
         (b"\x17", "bvelo", "Barometric Velocity", 4, float, "m/s", None),

--- a/Sensor/create_sensors.py
+++ b/Sensor/create_sensors.py
@@ -36,7 +36,7 @@ def flight_computer_rev2_sensors() -> List[Sensor]:
         (b"\x12", "velo_z", "Velo Z", 4, float, "m/s", None),
 
         (b"\x13", "pos", "Position", 4, float, "m", None),
-        (b"\x14", "pres", "Barometric Pressure", 4, float, "kPa", None),
+        (b"\x14", "pres", "Barometric Pressure", 4, float, "Pa", None),
         (b"\x15", "temp", "Barometric Temperature", 4, float, "C", None),
         (b"\x16", "alt", "Barometric Altitude", 4, float, "m", None),
         (b"\x17", "bvelo", "Barometric Velocity", 4, float, "m/s", None),

--- a/SerialController/serial_controller.py
+++ b/SerialController/serial_controller.py
@@ -153,6 +153,18 @@ class SerialObj:
             self.serialObj.reset_input_buffer()
         except serial.SerialException as e:
             raise SerialError(e)
+        
+    def reset_output_buffer(self) -> None:
+        """
+        Reset the output buffer of the serial port.
+        
+        Returns:
+            None
+        """
+        try:
+            self.serialObj.reset_output_buffer()
+        except serial.SerialException as e:
+            raise SerialError(e)
 
     def pretty_print(self, indent=0):
         """


### PR DESCRIPTION
Simple one-liner

Currently, the "sensor dump" command applies a conversion to the barometric pressure from Pa to kPa. This is nice for most readability, but it's inconsistent with the rest of the system. This PR simply removes that conversion and updates the unit.

I may have @NArmistead approve this depending on your activity level here.

Parent: https://github.com/SunDevilRocketry/Flight-Computer-Firmware/pull/288